### PR TITLE
composer dependency and pageModel attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,12 +45,5 @@
 	"support": {
 		"issues": "https://github.com/chopsol/contao-matomo-tracker/issues",
 		"source": "https://github.com/chopsol/contao-matomo-tracker"
-	},
-	"config": {
-		"allow-plugins": {
-			"php-http/discovery": true,
-			"contao-components/installer": true,
-			"contao/manager-plugin": true
-		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
 		"contao/manager-plugin": "<2.0 || >=3.0"
 	},
 	"require-dev": {
-		"contao/manager-plugin": "^2.0",
-		"contao/php-cs-fixer": "^2.0"
+		"contao/manager-plugin": "^2.0"
 	},
 	"extra": {
 		"contao-manager-plugin": "Chopsol\\ContaoMatomoTracker\\ContaoManager\\Plugin"
@@ -46,5 +45,12 @@
 	"support": {
 		"issues": "https://github.com/chopsol/contao-matomo-tracker/issues",
 		"source": "https://github.com/chopsol/contao-matomo-tracker"
+	},
+	"config": {
+		"allow-plugins": {
+			"php-http/discovery": true,
+			"contao-components/installer": true,
+			"contao/manager-plugin": true
+		}
 	}
 }

--- a/src/EventListener/MatomoTracking.php
+++ b/src/EventListener/MatomoTracking.php
@@ -40,6 +40,14 @@ class MatomoTracking {
 			return;
 		}
 
+        if(is_int($page) === true){
+            $page = PageModel::findById($page);
+        }
+
+        if(!$page instanceof PageModel){
+            return;
+        }
+
 		if ($rootPage = PageModel::findByPk($page->rootId)) {
 
 			$GLOBALS['COMATRACK_INIT'] = false;
@@ -269,7 +277,7 @@ class MatomoTracking {
 		if (isset($_SERVER['REQUEST_TIME_FLOAT'])) {
 			$matomoTracker->setGenerationTime((int)$gentime);
 		}
-		
+
 		// DoNotTrack in einem CustomDimension schreiben sofern konfiguriert
 		if (isset($GLOBALS['COMATRACK_SETTINGS']['dnt_dim']) && (int)$GLOBALS['COMATRACK_SETTINGS']['dnt_dim'] > 0) {
 			if (isset($_SERVER['HTTP_DNT']) && $_SERVER['HTTP_DNT'] == '1') {


### PR DESCRIPTION
removed php-cs-fixer dependency in composer.json to avoid composer installation failures (dev).

added check for int value from pageModel attribute (see manipulation of this attribute in other core component, can be int)